### PR TITLE
Mask SIGALRM and SIGVTALRM instead of using forkOS

### DIFF
--- a/w1-therm-haskell.cabal
+++ b/w1-therm-haskell.cabal
@@ -25,6 +25,7 @@ library
                      , filepath
                      , MissingH
                      , bytestring
+                     , unix
   default-language:    Haskell2010
 
 executable w1-therm-haskell-exe


### PR DESCRIPTION
To give the read() syscall on the sensor a chance to finish, mask SIGALRM and SIGVTALRM until it does.

Fixes #1 